### PR TITLE
 Ensure there are results in the session before calculating best time

### DIFF
--- a/src/components/Statistics.js
+++ b/src/components/Statistics.js
@@ -9,7 +9,7 @@ const calculateStatistics = (results) => {
 
   return {
     // Best single in the entire session.
-    bestSingle: Math.min(...times),
+    bestSingle: times.length > 0 ? Math.min(...times) : null,
     // Mean ignoring DNF results.
     globalMean: times.length ? mean(times) : null,
     // Average ignoring DNF results.


### PR DESCRIPTION
Previously, the statistic said NaN if there were no results in the session.