### PR TITLE
PB notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
+    "redux-saga": "^0.16.0",
     "reselect": "^3.0.0",
     "styled-components": "^3.3.3",
     "styled-components-theme": "^1.0.5",

--- a/src/actions/results.js
+++ b/src/actions/results.js
@@ -1,5 +1,4 @@
 import uuid from 'uuid/v4';
-
 import { generateScramble } from '../utils/scrambles';
 
 /**

--- a/src/actions/statistics.js
+++ b/src/actions/statistics.js
@@ -1,0 +1,27 @@
+export const NEW_RECORD = 'NEW_RECORD';
+export const SHOW_RECORD_MESSAGE = 'SHOW_RECORD_MESSAGE';
+export const HIDE_RECORD_MESSAGE = 'HIDE_RECORD_MESSAGE';
+
+/**
+ * Used by the statistics saga to start the process
+ * which shows the message and hides it some time later.
+ */
+export const newRecord = records => ({
+  type: NEW_RECORD,
+  records,
+});
+
+/**
+ * Displays the record message.
+ */
+export const showRecordMessage = records => ({
+  type: SHOW_RECORD_MESSAGE,
+  records,
+});
+
+/**
+ * Hides the record message.
+ */
+export const hideRecordMessage = () => ({
+  type: HIDE_RECORD_MESSAGE,
+});

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,6 +5,7 @@ import ResultManager from '../containers/ResultManager';
 import ScrambleManager from '../containers/ScrambleManager';
 import Sidebar from './Sidebar';
 import ResultColumn from './ResultColumn'
+import PersonalBestContainer from '../containers/PersonalBestContainer';
 
 const App = styled.div`
   display: flex;
@@ -31,6 +32,7 @@ const Main = styled.main`
 export default () => (
   <ThemeProvider theme={colors}>
     <App>
+      <PersonalBestContainer />
       <ScrambleManager />
       <Container>
         <ResultColumn />

--- a/src/components/PersonalBest.js
+++ b/src/components/PersonalBest.js
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const arrayToString = array => {
+  if (array.length === 1) {
+    return array[0];
+  }
+
+  const last = array.slice().pop();
+
+  return `${array.slice(0, array.length - 1).join(', ')} and ${last}`;
+};
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+`;
+
+const slideUp = keyframes`
+  from {
+    bottom: 0;
+  }
+
+  to {
+    bottom: 2rem;
+  }
+`;
+
+class PersonalBest extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      results: [],
+    };
+  }
+
+  componentDidUpdate(oldProps) {
+    const descriptions = {
+      bestSingle: 'single',
+      bestAo5: 'average of 5',
+      bestAo12: 'average of 12',
+      bestAo100: 'average of 100',
+    };
+
+    const records = Object.keys(descriptions)
+      .filter(key => this.props.statistics[key] && (!oldProps.statistics[key] ||
+        this.props.statistics[key] < oldProps.statistics[key]));
+
+    if (records.length > 0) {
+      this.setState({
+        records: records.map(key => descriptions[key]),
+      });
+
+      this.props.handleRecord();
+    }
+  }
+
+  render() {
+    const Toast = styled.div`
+      visibility: ${this.props.visible ? 'visible' : 'hidden'};
+      position: fixed;      
+      left: 50%;
+      transform: translateX(-50%);
+      background: #333;
+      color: #FFF;
+      padding: 1rem;
+      bottom: 2rem;
+      animation: ${fadeIn} 0.5s, ${slideUp} 0.5s ;
+    `;
+
+    return (
+      <Toast>
+        New personal best {this.state.records && arrayToString(this.state.records)}.
+      </Toast>
+    );
+  }
+}
+
+export default PersonalBest;

--- a/src/components/PersonalBest.js
+++ b/src/components/PersonalBest.js
@@ -41,6 +41,12 @@ class PersonalBest extends Component {
   }
 
   componentDidUpdate(oldProps) {
+    // Return instantly if the feature is disabled. Currently, the feature
+    // is disabled only when the algorithm scrambler is selected.
+    if (this.props.disabled) {
+      return;
+    }
+
     const descriptions = {
       bestSingle: 'single',
       bestAo5: 'average of 5',
@@ -62,6 +68,7 @@ class PersonalBest extends Component {
   }
 
   render() {
+    console.log(this.props)
     const Toast = styled.div`
       visibility: ${this.props.visible ? 'visible' : 'hidden'};
       position: fixed;      

--- a/src/components/Statistics.js
+++ b/src/components/Statistics.js
@@ -1,72 +1,43 @@
 import React from 'react';
 import styled from 'styled-components';
-import { average, mean } from '../utils/statistics';
 import { formatElapsedTime } from '../utils/time';
-import { isDNF, fastestCubingAverage, cubingAverage, timesFromResults } from '../utils/cubingStatistics';
-
-const calculateStatistics = (results) => {
-  const times = timesFromResults(results);
-
-  return {
-    // Best single in the entire session.
-    bestSingle: times.length > 0 ? Math.min(...times) : null,
-    // Mean ignoring DNF results.
-    globalMean: times.length ? mean(times) : null,
-    // Average ignoring DNF results.
-    globalAverage: times.length >= 5 ? average(times) : null,
-    // 2 DNF results means both mean and average are also DNF.
-    globalDNF: isDNF(results),
-    // Fastest average of 5.
-    bestAo5: fastestCubingAverage(results, 5),
-    // Fastest average of 12.
-    bestAo12: fastestCubingAverage(results, 12),
-    // Current average of 5.
-    curAo5: results.length >= 5 ? cubingAverage(results.slice(-5)) : null,
-    // Current average of 12.
-    curAo12: results.length >= 12 ? cubingAverage(results.slice(-12)) : null,
-    // Current average of 100.
-    curAo100: results.length >= 100 ? cubingAverage(results.slice(-100)) : null,
-    // Best average of 100.
-    bestAo100: fastestCubingAverage(results, 100),
-  };
-};
 
 const StatList = styled.ul`
   margin: 0;
 `;
 
-const Statistics = ({ results }) => {
-  const stats = calculateStatistics(results);
+const Statistics = ({ statistics, resultCount }) => {
+  const descriptions = {
+    bestSingle: 'Best single',
+    bestAo5: 'Best average of 5',
+    bestAo12: 'Best average of 12',
+    bestAo100: 'Best average of 100',
+    curAo5: 'Current average of 5',
+    curAo12: 'Current average of 12',
+    curAo100: 'Current average of 100',
+  };
 
-  const globalMean = stats.globalMean ?
-    stats.globalDNF ? `DNF (${formatElapsedTime(stats.globalMean, 2)})` : formatElapsedTime(stats.globalMean, 2) :
-    'N/A';
+  const globalMean = statistics.globalMean ?
+    statistics.globalDNF ? `DNF (${formatElapsedTime(statistics.globalMean, 2)})`
+      : formatElapsedTime(statistics.globalMean, 2) : 'N/A';
 
-  const globalAverage = stats.globalAverage ?
-    stats.globalDNF ? `DNF (${formatElapsedTime(stats.globalAverage, 2)})` : formatElapsedTime(stats.globalAverage, 2) :
-    'N/A';
-
-  const bestSingle = stats.bestSingle ? formatElapsedTime(stats.bestSingle, 2) : 'N/A';
-  const bestAo5 = stats.bestAo5 ? formatElapsedTime(stats.bestAo5, 2) : 'N/A';
-  const bestAo12 = stats.bestAo12 ? formatElapsedTime(stats.bestAo12, 2) : 'N/A';
-  const curAo5 = stats.curAo5 ? formatElapsedTime(stats.curAo5, 2) : 'N/A';
-  const curAo12 = stats.curAo12 ? formatElapsedTime(stats.curAo12, 2) : 'N/A';
-  const curAo100 = stats.curAo100 ? formatElapsedTime(stats.curAo100, 2) : 'N/A';
-  const bestAo100 = stats.bestAo100 ? formatElapsedTime(stats.curAo100, 2) : 'N/A';
+  const globalAverage = statistics.globalAverage ?
+    statistics.globalDNF ? `DNF (${formatElapsedTime(statistics.globalAverage, 2)})`
+      : formatElapsedTime(statistics.globalAverage, 2) : 'N/A';
 
   return (
-    <div className="Statistics">
+    <div>
       <StatList>
-        <li>Number of times: {results.length}</li>
-        <li>Best single: {bestSingle}</li>
+        <li>Number of times: {resultCount}</li>
         <li>Global mean: {globalMean}</li>
         <li>Global average: {globalAverage}</li>
-        <li>Best ao5: {bestAo5}</li>
-        <li>Best ao12: {bestAo12}</li>
-        <li>Current ao5: {curAo5}</li>
-        <li>Current ao12: {curAo12}</li>
-        <li>Current ao100: {curAo100}</li>
-        <li>Best ao100: {bestAo100}</li>
+
+        {Object.keys(descriptions).map(key =>
+          <li key={key}>
+            {descriptions[key]}: {statistics[key] ?
+              formatElapsedTime(statistics[key], 2) : 'N/A'}
+          </li>
+        )}
       </StatList>
     </div>
   );

--- a/src/containers/PersonalBestContainer.js
+++ b/src/containers/PersonalBestContainer.js
@@ -1,9 +1,11 @@
 import { connect } from 'react-redux';
 import { newRecord } from '../actions/statistics';
 import { statisticsSelector } from '../selectors/statistics';
+import { selectedScramblerSelector } from '../selectors/sessions';
 import PersonalBest from '../components/PersonalBest';
 
 const mapStateToProps = state => ({
+  disabled: selectedScramblerSelector(state) === 'algs',
   statistics: statisticsSelector(state),
   visible: state.recordMessageIsVisible,
 });

--- a/src/containers/PersonalBestContainer.js
+++ b/src/containers/PersonalBestContainer.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import { newRecord } from '../actions/statistics';
+import { statisticsSelector } from '../selectors/statistics';
+import PersonalBest from '../components/PersonalBest';
+
+const mapStateToProps = state => ({
+  statistics: statisticsSelector(state),
+  visible: state.recordMessageIsVisible,
+});
+
+const mapDispatchToProps = dispatch => ({
+  handleRecord: records => {
+    dispatch(newRecord(records));
+  },
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PersonalBest);

--- a/src/containers/StatisticsContainer.js
+++ b/src/containers/StatisticsContainer.js
@@ -1,11 +1,15 @@
 import { connect } from 'react-redux';
 import { getResults } from '../selectors/results';
 import Statistics from '../components/Statistics';
+import { statisticsSelector } from '../selectors/statistics';
 
 const mapStateToProps = (state) => ({
-  results: getResults(state),
+  resultCount: getResults(state).length,
+  statistics: statisticsSelector(state),
 });
 
-const StatisticsContainer = connect(mapStateToProps)(Statistics);
+const StatisticsContainer = connect(
+  mapStateToProps,
+)(Statistics);
 
 export default StatisticsContainer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,11 +1,13 @@
 import { selectedSession, sessions } from './sessions';
 import { sets, selectedSet, currentAlgorithm } from './sets';
+import recordMessageIsVisible from './statistics';
 
 const timerApp = (state = {}, action) => {
   const updatedState = {
     selectedSet: selectedSet(state.selectedSet, action),
     sets: sets(state.sets, action),
     currentAlgorithm: currentAlgorithm(state.currentAlgorithm, action),
+    recordMessageIsVisible: recordMessageIsVisible(state.recordMessageIsVisible, action),
   };
 
   updatedState.sessions = sessions(

--- a/src/reducers/statistics.js
+++ b/src/reducers/statistics.js
@@ -1,0 +1,16 @@
+import { SHOW_RECORD_MESSAGE, HIDE_RECORD_MESSAGE } from '../actions/statistics';
+
+const recordMessageIsVisible = (state = false, action) => {
+  switch (action.type) {
+    case  SHOW_RECORD_MESSAGE:
+      return true;
+
+    case HIDE_RECORD_MESSAGE:
+      return false;
+
+    default:
+      return state;
+  }
+};
+
+export default recordMessageIsVisible;

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,0 +1,8 @@
+import { all } from 'redux-saga/effects';
+import statisticsSaga from './statistics';
+
+export default function* rootSaga() {
+  yield all([
+    statisticsSaga(),
+  ]);
+}

--- a/src/sagas/statistics.js
+++ b/src/sagas/statistics.js
@@ -1,0 +1,18 @@
+import { takeLatest, put } from 'redux-saga/effects';
+
+import {
+  NEW_RECORD, showRecordMessage,
+  hideRecordMessage,  
+} from '../actions/statistics';
+
+const delay = (ms) => new Promise(res => setTimeout(res, ms));
+
+function* newRecord(action) {
+  yield put(showRecordMessage(action.records));
+  yield delay(5000);
+  yield put(hideRecordMessage());
+}
+
+export default function* statisticsSaga() {
+  yield takeLatest(NEW_RECORD, newRecord);
+}

--- a/src/selectors/statistics.js
+++ b/src/selectors/statistics.js
@@ -1,0 +1,12 @@
+import { createSelector } from 'reselect';
+import { getResults } from './results';
+import { calculateStatistics } from '../utils/cubingStatistics';
+
+/**
+ * Returns an object containing different types of
+ * statistics concerning the current array of results.
+ */
+export const statisticsSelector = createSelector(
+  getResults,
+  results => calculateStatistics(results),
+);

--- a/src/store.js
+++ b/src/store.js
@@ -1,14 +1,20 @@
 import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga'
 import logger from 'redux-logger'
 import timerApp from './reducers';
+import rootSaga from './sagas';
 
 const initialState = localStorage.state ? JSON.parse(localStorage.state) : undefined;
+
+const sagaMiddleware = createSagaMiddleware();
 
 const store = createStore(
   timerApp,
   initialState,
-  applyMiddleware(logger)
+  applyMiddleware(logger, sagaMiddleware),
 );
+
+sagaMiddleware.run(rootSaga);
 
 store.subscribe(() => {
   localStorage.setItem('state', JSON.stringify(store.getState()));

--- a/src/utils/cubingStatistics.js
+++ b/src/utils/cubingStatistics.js
@@ -1,4 +1,4 @@
-import { average } from './statistics';
+import { average, mean } from './statistics';
 
 // Returns whether a given list of results is a DNF average or not.
 export const isDNF = (results) => results.filter((r) => r.dnf).length >= 2;
@@ -42,4 +42,31 @@ export const fastestCubingAverage = (results, num) => {
   const fastest = Math.min.apply(Math, averages.filter((r) => isFinite(r)));
 
   return isFinite(fastest) ? fastest : 'DNF';
+};
+
+export const calculateStatistics = (results) => {
+  const times = timesFromResults(results);
+
+  return {
+    // Best single in the entire session.
+    bestSingle: times.length > 0 ? Math.min(...times) : null,
+    // Mean ignoring DNF results.
+    globalMean: times.length ? mean(times) : null,
+    // Average ignoring DNF results.
+    globalAverage: times.length >= 5 ? average(times) : null,
+    // 2 DNF results means both mean and average are also DNF.
+    globalDNF: isDNF(results),
+    // Fastest average of 5.
+    bestAo5: fastestCubingAverage(results, 5),
+    // Fastest average of 12.
+    bestAo12: fastestCubingAverage(results, 12),
+    // Current average of 5.
+    curAo5: results.length >= 5 ? cubingAverage(results.slice(-5)) : null,
+    // Current average of 12.
+    curAo12: results.length >= 12 ? cubingAverage(results.slice(-12)) : null,
+    // Current average of 100.
+    curAo100: results.length >= 100 ? cubingAverage(results.slice(-100)) : null,
+    // Best average of 100.
+    bestAo100: fastestCubingAverage(results, 100),
+  };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6685,6 +6685,10 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
+redux-saga@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
+
 redux@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"


### PR DESCRIPTION
Adds PB notifications by displaying a simple toast message when a record is broken in the current session. The feature is disabled when the `algs` scrambler is being used. In the future, it should be possible to disable these notifications on the settings page.